### PR TITLE
Nexus workflow aka. publish to maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.2.3'
-        classpath 'com.github.dcendents:android-maven-plugin:1.2'
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath 'com.adaptc.gradle:nexus-workflow:0.6'
     }
 }
 

--- a/material_preferences_library/build.gradle
+++ b/material_preferences_library/build.gradle
@@ -1,5 +1,11 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'maven'
+apply plugin: 'signing'
+apply plugin: 'nexus-workflow'
+
+group = "com.lb.material_preferences_library"
+archivesBaseName = "material_preferences_library"
+version = "1.0"
 
 android {
     compileSdkVersion 22
@@ -9,7 +15,7 @@ android {
         minSdkVersion 7
         targetSdkVersion 22
         versionCode 1
-        versionName "1.0"
+        versionName version
     }
     buildTypes {
         release {
@@ -23,7 +29,62 @@ android {
     }
 }
 
+configurations {
+    archives {
+        extendsFrom configurations.default
+    }
+}
+
+signing {
+    sign configurations.archives
+}
+
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.android.support:appcompat-v7:22.2.0'
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
+
+            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
+
+            pom.project {
+                name 'MaterialPreferenceLibrary'
+                packaging 'jar'
+                // optionally artifactId can be defined here
+                description 'Allows to have an ActionBar on PreferenceActivity, even on pre-Honeycomb versions of Android'
+                url 'https://github.com/AndroidDeveloperLB/MaterialPreferenceLibrary'
+
+                scm {
+                    connection 'scm:git:https://github.com/AndroidDeveloperLB/MaterialPreferenceLibrary.git'
+                    developerConnection 'scm:git:https://github.com/AndroidDeveloperLB/MaterialPreferenceLibrary.git'
+                    url 'https://github.com/AndroidDeveloperLB/MaterialPreferenceLibrary'
+                }
+
+                licenses {
+                    license {
+                        name 'The Apache License, Version 2.0'
+                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id 'yourUsername'
+                        name 'Your Name'
+                        email 'your.email@example.com'
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
I noticed issue https://github.com/AndroidDeveloperLB/MaterialPreferenceLibrary/issues/4 about publishing the library to maven. I would really appreciate if you do this. JitPack is not a good long term solution.

I have added some boilerplate configuration here for publishing to sonatype oss using the nexus-workflow plugin.

What you need to do on your part is a one time setup with sonatype. After that publishing is just two clicks inside Android Studio.

You go to http://central.sonatype.org/pages/ossrh-guide.html and look under the "Initial setup"-section. Follow the like so create a JIRA account and then open a Project Ticket.

After that the boilerplate config will expect a file at `~/gradle/gradle.properties` containing credentials for sonatype. Please refer to my blog post about this config, https://victorhaggqvist.com/blog/2015/how-to-publish-an-android-library-to-maven.html. I wrote that post as a future reference when I did my setup.
