### PR TITLE
Custom ripple xml for android 6

### DIFF
--- a/material_preferences_library/src/main/res/drawable-v21/mpl__custom_ripple_effect_background.xml
+++ b/material_preferences_library/src/main/res/drawable-v21/mpl__custom_ripple_effect_background.xml
@@ -1,0 +1,10 @@
+<ripple
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="#a5a5a5">
+    <item>
+        <shape
+            android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+</ripple>

--- a/material_preferences_library/src/main/res/drawable/mpl__custom_ripple_effect_background.xml
+++ b/material_preferences_library/src/main/res/drawable/mpl__custom_ripple_effect_background.xml
@@ -1,0 +1,12 @@
+<ripple
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:color="#a5a5a5"
+    tools:targetApi="lollipop">
+    <item>
+        <shape
+            android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+</ripple>

--- a/material_preferences_library/src/main/res/drawable/mpl__custom_ripple_effect_background.xml
+++ b/material_preferences_library/src/main/res/drawable/mpl__custom_ripple_effect_background.xml
@@ -1,12 +1,21 @@
-<ripple
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:color="#a5a5a5"
-    tools:targetApi="lollipop">
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape
             android:shape="rectangle">
             <solid android:color="@android:color/transparent" />
         </shape>
     </item>
-</ripple>
+    <item android:state_pressed="true">
+        <shape
+            android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+    <item android:state_focused="true">
+        <shape
+            android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+</selector>

--- a/material_preferences_library/src/main/res/layout/mpl__preference_activity.xml
+++ b/material_preferences_library/src/main/res/layout/mpl__preference_activity.xml
@@ -25,7 +25,8 @@
     <ListView
       android:id="@android:id/list"
       android:layout_width="match_parent"
-      android:layout_height="match_parent"/>
+      android:layout_height="match_parent"
+      android:listSelector="@drawable/mpl__custom_ripple_effect_background"/>
 
     <ImageView
       android:id="@+id/abp__shadowView"


### PR DESCRIPTION
Click event to center of list item still occurs sometimes even user clicks to corner of item. This removes double ripple effect when that occurs. Tested on android 4.1.2 , 4.4 , 5.0 , 6.0
